### PR TITLE
Maintain build history on master and revert updates to behat-drush-endpoint

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,8 +72,8 @@ steps:
 #   condition: and(succeededOrFailed(), eq(variables.RUN_TESTS, 'true'))
 
 # Build Assets (Composer Install)
-- script: ./.ci/build/php
-  displayName: 'Build PHP'
+# - script: ./.ci/build/php
+#   displayName: 'Build PHP'
 
 - script: ./.ci/deploy/pantheon/dev-multidev
   displayName: 'Deploy to Pantheon'
@@ -199,12 +199,17 @@ steps:
 - script: |
     git config user.name '$(Build.RequestedFor)'
     git config user.email '$(Build.RequestedForEmail)'
-    git checkout master
-    git pull origin/master
-    git merge --no-commit develop
-    composer -n build-assets
+    
+    git branch
+    git remote -v
+
+    # git checkout master
+    # git merge --no-commit develop
+    # composer -n build-assets
+
     git add --force -A .
     git commit -m 'Build $(Build.BuildId)'
+
     # git push --force https://$(pat)@github.com/ccswbs/drupal-8-composer.git HEAD:master
   displayName: 'Push to upstream'
   condition: and(succeeded(),eq(variables['Build.SourceBranch'],'refs/heads/fix-master-push'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -199,11 +199,15 @@ steps:
 - script: |
     git config user.name '$(Build.RequestedFor)'
     git config user.email '$(Build.RequestedForEmail)'
+    git checkout master
+    git pull origin/master
+    git merge --no-commit develop
+    composer -n build-assets
     git add --force -A .
     git commit -m 'Build $(Build.BuildId)'
-    git push --force https://$(pat)@github.com/ccswbs/drupal-8-composer.git HEAD:master
+    # git push --force https://$(pat)@github.com/ccswbs/drupal-8-composer.git HEAD:master
   displayName: 'Push to upstream'
-  condition: and(succeeded(),eq(variables['Build.SourceBranch'],'refs/heads/develop'))
+  condition: and(succeeded(),eq(variables['Build.SourceBranch'],'refs/heads/fix-master-push'))
 
 # Clean up
 - script: ./.ci/env/clean

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,8 +72,8 @@ steps:
 #   condition: and(succeededOrFailed(), eq(variables.RUN_TESTS, 'true'))
 
 # Build Assets (Composer Install)
-# - script: ./.ci/build/php
-#   displayName: 'Build PHP'
+- script: ./.ci/build/php
+  displayName: 'Build PHP'
 
 - script: ./.ci/deploy/pantheon/dev-multidev
   displayName: 'Deploy to Pantheon'
@@ -199,17 +199,22 @@ steps:
 - script: |
     git config user.name '$(Build.RequestedFor)'
     git config user.email '$(Build.RequestedForEmail)'
-    
-    git remote -v
-    git checkout fix-master-push
-    git fetch origin master
-    git branch
-    git checkout master
-    git merge --no-commit fix-master-push
-    composer -n build-assets
 
+    # Check out both branches so they exist on the pipeline
+    git checkout $(Build.SourceBranchName)
+    git checkout master
+
+    # Merge source branch onto latest version of master
+    git fetch origin master
+    git merge --no-commit $(Build.SourceBranchName)
+
+    # Build assets
+    composer -n build-assets
     git add --force -A .
     git commit -m 'Build $(Build.BuildId)'
+
+    # Show differences
+    git diff origin/master --name-only
 
     # git push --force https://$(pat)@github.com/ccswbs/drupal-8-composer.git HEAD:master
   displayName: 'Push to upstream'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -200,12 +200,13 @@ steps:
     git config user.name '$(Build.RequestedFor)'
     git config user.email '$(Build.RequestedForEmail)'
     
-    git branch
     git remote -v
+    git fetch origin master
+    git branch
 
-    # git checkout master
-    # git merge --no-commit develop
-    # composer -n build-assets
+    git checkout master
+    git merge --no-commit fix-master-push
+    composer -n build-assets
 
     git add --force -A .
     git commit -m 'Build $(Build.BuildId)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,15 +210,15 @@ steps:
 
     # Build assets
     composer -n build-assets
+
+    # Commit changes
     git add --force -A .
     git commit -m 'Build $(Build.BuildId)'
 
-    # Show differences
-    git log --oneline
-
-    # git push --force https://$(pat)@github.com/ccswbs/drupal-8-composer.git HEAD:master
+    # Push to master
+    git push --force https://$(pat)@github.com/ccswbs/drupal-8-composer.git HEAD:master
   displayName: 'Push to upstream'
-  condition: and(succeeded(),eq(variables['Build.SourceBranch'],'refs/heads/fix-master-push'))
+  condition: and(succeeded(),eq(variables['Build.SourceBranch'],'refs/heads/develop'))
 
 # Clean up
 - script: ./.ci/env/clean

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,9 +201,9 @@ steps:
     git config user.email '$(Build.RequestedForEmail)'
     
     git remote -v
+    git checkout fix-master-push
     git fetch origin master
     git branch
-
     git checkout master
     git merge --no-commit fix-master-push
     composer -n build-assets

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -214,7 +214,7 @@ steps:
     git commit -m 'Build $(Build.BuildId)'
 
     # Show differences
-    git diff origin/master --name-only
+    git log --oneline
 
     # git push --force https://$(pat)@github.com/ccswbs/drupal-8-composer.git HEAD:master
   displayName: 'Push to upstream'

--- a/drush/Commands/contrib/behat-drush-endpoint/composer.lock
+++ b/drush/Commands/contrib/behat-drush-endpoint/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e6d85d0b4eb60af48c537c7ad072776",
+    "content-hash": "874dea09e7a8ff500f5e1e723a72bb5f",
     "packages": [
         {
             "name": "drupal/core-render",
@@ -238,16 +238,16 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.4.37",
+            "version": "v3.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "22000f10c9e1cfef051e8b4de46815b41a0223fc"
+                "reference": "09d7df7bf06c1393b6afc85875993cbdbdf897a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/22000f10c9e1cfef051e8b4de46815b41a0223fc",
-                "reference": "22000f10c9e1cfef051e8b4de46815b41a0223fc",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/09d7df7bf06c1393b6afc85875993cbdbdf897a0",
+                "reference": "09d7df7bf06c1393b6afc85875993cbdbdf897a0",
                 "shasum": ""
             },
             "require": {
@@ -305,7 +305,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-08T11:20:51+00:00"
+            "time": "2018-08-08T11:42:34+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",


### PR DESCRIPTION
- Fix deploy to master so the build history is maintained
   - checkout master
   - merge in develop with --no-commit
   - build assets using composer
   - commit changes
   - push to master
- Updates to behat-drush-endpoint are being rebuilt by composer with older version. Reverting to previous state of behat-drush-endpoint.

Note: I will squash the commits to make them tidy.
