### PR TITLE
Allow users to use an ignored appsettings.local.json file

### DIFF
--- a/tests/selenium/.gitignore
+++ b/tests/selenium/.gitignore
@@ -259,4 +259,4 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
-/BoveyTest/appsettings.json
+BoveyTest/appsettings.local.json

--- a/tests/selenium/BoveyTest/Authentication.cs
+++ b/tests/selenium/BoveyTest/Authentication.cs
@@ -9,11 +9,12 @@ namespace BoveyTest
     public class Authentication : DrupalTest
     {
         [TestInitialize]
-        [DeploymentItem("appsettings.json")]
+        [DeploymentItem("appsettings*.json")]
         public void Initialize()
         {
             var config = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.json")
+                .AddJsonFile("appsettings.local.json", optional:true)
                 .Build();
             base.Initialize(config["TestQAHostname"], config["basePath"]);
             DrupalLogin(config["TestQAUsername"], config["TestQAPassword"]);

--- a/tests/selenium/BoveyTest/BoveyTest.csproj
+++ b/tests/selenium/BoveyTest/BoveyTest.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="appsettings.json">
+    <None Update="appsettings*json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
- Allow users to create a local file called appsettings.local.json that they can save locally on their computer. This helps us avoid the scenario where a user is locally updating appsettings.json with a password, but then accidentally commits their changes.
- The file is ignored (via .gitignore)

**Manual Run with Tests (passed):** https://dev.azure.com/uoguelph/CCS/_build/results?buildId=273&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=12f1170f-54f2-53f3-20dd-22fc7dff55f9

## Story (Acceptance Criteria - micro level)
- [x] Story maintains a clear separation between layout and content (no layout references on Content Hub).
- [x] Remaining hours for tasks set to zero and tasks closed.

### Is Content created by the story?
- [x] No
- [ ] If yes, the content is:
   - Accessible
   - Mobile-friendly
   - Version-controlled
   - Governed by appropriate roles and permissions
   - Organized by taxonomy

### Are there User-facing changes?
- [x] No
- [ ] If yes, then:
   - User documentation is updated
   - User training is updated

### Are there Upstream Code changes?
- [ ] No
- [x] If yes, then:
   - [x] Code is complete, commented, and mergeable against *develop* branch.
   - [x] Code is secure to the best of our knowledge and does not contain anything that cannot be on a public repo (e.g. passwords)
   - [ ] Add a test if existing tests do not effectively test the code change and test builds without error
   - [x] Pull request (PR) created to merge against *develop*
   - [x] PR has a meaningful title
   -  [x] PR has a summary of changes
   -  [ ] PR is peer reviewed and meets team standards.
   -  [x] PR builds without error
   -  [ ] PR merged with *develop*

### Are there Site Configuration changes?
- [x] No
- [ ] If yes, then:
   - Use a multidev
   - Add any modules to the upstream with composer (not through the Drupal UI)
   - If changes expose additional APIs (e.g. JSON), ensure site has been configured to account for this.
   - Do not reference layout in site configuration (e.g. content types, fields, labels)
   - Provide user guidance where possible
   - Confirm multidev status report does introduce new errors
   - Ensure only necessary site configuration changes are exported
   - Export and commit site-configuration on multidev
   - Configuration is secure to the best of your knowledge
   - Multidev peer reviewed and meets team standards
   - Multidev merged with Dev environment