### PR TITLE
Add Editorial Workflow selenium tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,41 +156,6 @@ steps:
 #     pathtoPublish: '$(Build.ArtifactStagingDirectory)'
 #     artifactName: BehatTestFailureScreenshots
 
-# Visual Regression Tests
-# - script: ./.ci/test/visual-regression/run
-#   displayName: '[BackstopJS] Run visual regression tests'
-#   condition: and(succeededOrFailed(), eq(variables.RUN_TESTS, 'true'))
-
-# - bash: |
-#     if [ -d backstop_data ]; then
-#       echo "##vso[task.setVariable variable=BACKSTOP_DATA_EXISTS]true"
-#     fi
-#   displayName: '[BackstopJS] Check if test results exist'
-#   condition: and(succeededOrFailed(), eq(variables.RUN_TESTS, 'true'))
-
-# - task: PublishTestResults@2
-#   displayName: '[BackstopJS] Publish test results'
-#   condition: and(succeededOrFailed(),eq(variables.BACKSTOP_DATA_EXISTS, 'true'),eq(variables.RUN_TESTS, 'true'))
-#   inputs:
-#     testResultsFormat: 'JUnit' # Options: JUnit, NUnit, VSTest, xUnit, cTest
-#     testResultsFiles: 'backstop_data/ci_report/*' 
-#     testRunTitle: 'BackstopJS Test Results'
-
-# - task: CopyFiles@2
-#   displayName: "[BackstopJS] Copy screenshots to Artifacts Directory"
-#   condition: and(succeededOrFailed(),eq(variables.BACKSTOP_DATA_EXISTS, 'true'),eq(variables.RUN_TESTS, 'true'))
-#   inputs:
-#       sourceFolder: 'backstop_data'
-#       contents: '**'
-#       targetFolder: '$(Build.ArtifactStagingDirectory)'
-
-# - task: PublishBuildArtifacts@1
-#   displayName: '[BackstopJS] Publish screenshots to Artifacts Directory'
-#   condition: and(succeededOrFailed(),eq(variables.BACKSTOP_DATA_EXISTS, 'true'),eq(variables.RUN_TESTS, 'true'))
-#   inputs:
-#     pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-#     artifactName: BackstopJSTestScreenshots
-
 # Composer Lock Updater
 - script: true
   displayName: 'Composer lock updater'

--- a/tests/selenium/BoveyTest/BoveyTest.csproj
+++ b/tests/selenium/BoveyTest/BoveyTest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DrupalTest" Version="1.0.7" />
+    <PackageReference Include="DrupalTest" Version="1.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />

--- a/tests/selenium/BoveyTest/BoveyTest.csproj
+++ b/tests/selenium/BoveyTest/BoveyTest.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DrupalTest" Version="1.0.11" />
+    <PackageReference Include="DrupalTest" Version="1.0.12" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />

--- a/tests/selenium/BoveyTest/EditorialWorkflow.cs
+++ b/tests/selenium/BoveyTest/EditorialWorkflow.cs
@@ -1,10 +1,7 @@
-using System;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Test;
-
-using OpenQA.Selenium;
 
 namespace BoveyTest
 {
@@ -317,13 +314,23 @@ namespace BoveyTest
             DrupalLogin(testUser.Name, testUser.Password);
 
             // set node to destination state
-            DrupalGet(nodeViewURL);
-            Select("edit-new-state",destinationState);
-            ScrollAndClick("edit-submit");
+            if(currentState == _publishedState){
+                DrupalGet(nodeViewURL + "/edit");
+                Select("edit-moderation-state-0-state", destinationState);
+                ScrollAndClick("edit-submit");
 
-            // confirm node was successfully updated
-            var successfulTransitionContentMessage = Driver.FindElementsByXPath($"//div[contains(@class, 'messages--status') and text()[contains(.,'The moderation state has been updated.')]]");
-            Assert.AreEqual(successfulTransitionContentMessage.Count, 1);
+                // confirm node was successfully updated
+                var successfulTransitionContentMessage = Driver.FindElementsByXPath($"//div[contains(@class, 'messages--status') and text()[contains(.,' has been updated.')]]");
+                Assert.AreEqual(successfulTransitionContentMessage.Count, 1);                
+            }else{
+                DrupalGet(nodeViewURL);
+                Select("edit-new-state", destinationState);
+                ScrollAndClick("edit-submit");
+
+                // confirm node was successfully updated
+                var successfulTransitionContentMessage = Driver.FindElementsByXPath($"//div[contains(@class, 'messages--status') and text()[contains(.,'The moderation state has been updated.')]]");
+                Assert.AreEqual(successfulTransitionContentMessage.Count, 1);
+            }
 
             // confirm workflow state was successfully updated
             AdminCan_ConfirmContent_InExpectedWorkflowState(nodeViewURL, destinationState);

--- a/tests/selenium/BoveyTest/EditorialWorkflow.cs
+++ b/tests/selenium/BoveyTest/EditorialWorkflow.cs
@@ -1,0 +1,391 @@
+using System;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Test;
+
+using OpenQA.Selenium;
+
+namespace BoveyTest
+{
+    [TestClass]
+    public class EditorialWorkflow : DrupalTest
+    {
+        private string _adminUser;
+        private string _adminPass;
+        private DrupalUser _testAuthor;
+        private DrupalUser _testEditor;
+        private DrupalUser _testReviewer;
+        private DrupalUser _testModerator;
+        private DrupalUser _testPublisher;
+        private DrupalUser _testAllRolesButPublisherAdmin;
+        private DrupalUser _testAllRolesButAdmin;
+
+        private DrupalNode _testContentNode = new DrupalNode() { NodeID = 0, Title = "" };
+
+        private string _testContentNodeEditPage;
+        private string _testContentNodeViewPage;
+
+        private string _draftState = "Draft";
+        private string _editState = "Edit";
+        private string _reviewState = "Review";
+        private string _moderationState = "Moderation";
+        private string _publishedState = "Published";
+        private string _archivedState = "Archived";
+        private string _accessDenied = "Access denied";
+
+
+        [TestInitialize]
+        [DeploymentItem("appsettings*.json")]
+        public void Initialize()
+        {
+            var config = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .AddJsonFile("appsettings.local.json", optional:true)
+                .Build();
+            base.Initialize(config["TestQAHostname"], config["basePath"]);
+            _adminUser = config["TestQAUsername"];
+            _adminPass = config["TestQAPassword"];
+            DrupalLogin(_adminUser, _adminPass);
+
+            string[] allRolesButPublisherAdmin = new string[] {
+                "author", 
+                "editor", 
+                "reviewer", 
+                "moderator"
+            };
+
+            string[] allRolesButAdmin = new string[] {
+                "author", 
+                "editor", 
+                "reviewer", 
+                "moderator", 
+                "publisher"
+            };
+
+            string[] extraCheckboxes = new string[] {
+                "edit-field-domain-access-api-liveugconthub-uoguelph-dev"
+            };
+
+            TurnOnLDAPMixedMode();
+            _testAuthor = CreateUser(new string[] {"author"}, false, extraCheckboxes);
+            _testEditor = CreateUser(new string[] {"editor"}, false, extraCheckboxes);
+            _testReviewer = CreateUser(new string[] {"reviewer"}, false, extraCheckboxes);
+            _testModerator = CreateUser(new string[] {"moderator"}, false, extraCheckboxes);
+            _testPublisher = CreateUser(new string[] {"publisher"}, false, extraCheckboxes);
+            _testAllRolesButPublisherAdmin = CreateUser(allRolesButPublisherAdmin, false, extraCheckboxes);
+            _testAllRolesButAdmin = CreateUser(allRolesButAdmin, false, extraCheckboxes);
+        }
+
+        [TestCleanup]
+        override public void Cleanup()
+        {
+            bool deleteContent = true;
+
+            // ----- CLEAN UP ----
+            DrupalLogout();
+            DrupalLogin(_adminUser, _adminPass);
+
+            // delete all selenium-test-users + content
+            DeleteUser(_testAuthor.Name);
+            DeleteUser(_testEditor.Name, deleteContent);
+            DeleteUser(_testReviewer.Name, deleteContent);
+            DeleteUser(_testModerator.Name, deleteContent);
+            DeleteUser(_testPublisher.Name, deleteContent);
+            DeleteUser(_testAllRolesButPublisherAdmin.Name, deleteContent);
+            DeleteUser(_testAllRolesButAdmin.Name, deleteContent);
+
+            TurnOffLDAPMixedMode();
+            DrupalLogout();
+
+            _driver.Quit();
+        }
+
+        [TestMethod]
+        public void BasicPageFlows_FromDraftToPublished(){
+            ContentFlows_FromDraftToPublished("page");
+        }
+
+        public void ContentFlows_FromDraftToPublished(string contentType)
+        {
+            // ----- DRAFT PHASE ----
+            AuthorCan_CreateDraft(contentType);
+            AuthorCan_UpdateContent_InDraftState();
+            AuthorCan_TransitionContent_FromDraftToEdit();
+
+            // ----- EDIT PHASE ----
+            AuthorCan_UpdateContent_InEditState();
+            AuthorCan_TransitionContent_FromEditToDraft();
+            AuthorCan_TransitionContent_FromDraftToEdit();
+
+            EditorCan_UpdateContent_InEditState();            
+            EditorCan_TransitionContent_FromEditToDraft();
+            AuthorCan_TransitionContent_FromDraftToEdit();
+            EditorCan_TransitionContent_FromEditToReview();
+            
+            // ----- REVIEW PHASE ----
+            
+            // [WARNING] Users with (author OR editor) AND (reviewer, moderator, or publisher) roles can update content in review state
+            // UsersCannot_UpdateContent_InReviewState();
+
+            ReviewerCan_ViewContent_InReviewState();
+            ReviewerCan_TransitionContent_FromReviewToEdit();
+            ReviewerCannot_TransitionContent_FromEditToReview();
+            EditorCan_TransitionContent_FromEditToReview();
+            ReviewerCan_TransitionContent_FromReviewToModerate();
+
+            // ----- MODERATION PHASE ----
+
+            // [WARNING] Users with (author OR editor) AND (reviewer, moderator, or publisher) roles can update content in review state
+            // UsersCannot_UpdateContent_InModerateState();
+            ModeratorCan_ViewContent_InModerateState();
+            ModeratorCan_TransitionContent_FromModerateToPublished();
+
+            // ----- PUBLISHED PHASE ----
+            // [WARNING] Users with (author OR editor) AND (reviewer, moderator, or publisher) roles can update content in review state
+            // UsersCannot_UpdateContent_InPublishedState();
+
+
+// [WARNING] Publisher cannot unpublish at the moment - no access to button
+
+            // OnlyPublisherCan_UnpublishContent();
+            // PublisherCan_TransitionContent_FromPublishedToArchived();
+            // PublisherCan_TransitionContent_FromArchivedToPublished();
+
+        }
+
+        void AuthorCan_CreateDraft(string contentType) {
+            UserCan_CreateContent(contentType, _testAuthor, _draftState, true);
+        }
+        void UserCan_CreateContent(string contentType, DrupalUser userToCheck, string workflowState, bool needToLogin = false) {
+            _testContentNode.Title = "Selenium Test Content for " + contentType;
+            string editText = "[Success] UserCan_CreateContent.";
+
+            if(needToLogin == true){
+                // login as user
+                DrupalLogout();
+                DrupalLogin(userToCheck.Name, userToCheck.Password);
+            }
+
+            // Create content
+            DrupalGet("node/add/" + contentType);
+            Type("edit-title-0-value", _testContentNode.Title);
+            
+            // Edit Body Field Wysiwyg in Source Mode
+            UpdateBodyField(editText);
+
+            // Set workflow state
+            Select("edit-moderation-state-0-state", workflowState);
+            ScrollAndClick("edit-submit");
+            
+            // Check if successful message appears after testing connection
+            var successfulCreateContentMessage = Driver.FindElementsByXPath($"//div[contains(@class, 'messages--status') and text()[contains(.,'has been created.')]]");
+            Assert.AreEqual(successfulCreateContentMessage.Count, 1);
+
+            // Set Node ID, edit page and view pages
+            var editLink = Driver.FindElementByXPath("//a[text()='Edit']");
+            string editURL = editLink.GetAttribute("href");
+            int nodeDelimeterPosition = editURL.IndexOf("/node/");
+            char[] charsToTrim = { '/'};
+
+            _testContentNodeEditPage = editURL.Substring(nodeDelimeterPosition);
+            _testContentNode.NodeID = int.Parse(Regex.Replace(_testContentNodeEditPage, "[^0-9.]", "").Trim(charsToTrim));
+            _testContentNodeViewPage = "/node/" + _testContentNode.NodeID;
+        }
+
+        void AuthorCan_UpdateContent_InDraftState(){
+            var editText = "[Success] AuthorCan_UpdateContent_InDraftState";
+            UserCan_UpdateContentAndSave(_testAuthor, _testContentNodeEditPage, editText, _draftState);
+        }
+
+        void AuthorCan_UpdateContent_InEditState(){
+            var editText = "[Success] AuthorCan_UpdateContent_InEditState";
+            UserCan_UpdateContentAndSave(_testAuthor, _testContentNodeEditPage, editText, _editState);
+        }
+
+        void EditorCan_UpdateContent_InEditState(){
+            var editText = "[Success] EditorCan_UpdateContent_InEditState";
+            UserCan_UpdateContentAndSave(_testEditor, _testContentNodeEditPage, editText, _editState);
+        }
+
+        void AuthorCan_TransitionContent_FromDraftToEdit(){
+            UserCan_TransitionContentAndSave(_testAuthor, _testContentNodeViewPage, _draftState, _editState);
+        }
+
+        void AuthorCan_TransitionContent_FromEditToDraft(){
+            UserCan_TransitionContentAndSave(_testAuthor, _testContentNodeViewPage, _editState, _draftState);
+        }
+
+        void EditorCan_TransitionContent_FromEditToDraft(){
+            UserCan_TransitionContentAndSave(_testEditor, _testContentNodeViewPage, _editState, _draftState);
+        }
+
+        void EditorCan_TransitionContent_FromEditToReview(){
+            UserCan_TransitionContentAndSave(_testEditor, _testContentNodeViewPage, _editState, _reviewState);
+        }
+
+        void ReviewerCan_ViewContent_InReviewState(){
+            UserCan_ViewContent(_testReviewer, _testContentNodeViewPage, _reviewState);
+        }
+
+        void ModeratorCan_ViewContent_InModerateState(){
+            UserCan_ViewContent(_testModerator, _testContentNodeViewPage, _moderationState);
+        }
+
+        void UserCan_ViewContent(DrupalUser testUser, string nodeURL, string expectedWorkflowState){
+            AdminCan_ConfirmContent_InExpectedWorkflowState(nodeURL, expectedWorkflowState);
+            DrupalLogin(testUser.Name, testUser.Password);
+            DrupalGet(nodeURL);
+            Assert.AreEqual(CheckIfViewPageTitleIsCorrect(_testContentNode.Title),true);
+        }
+        
+        void UsersCannot_UpdateContent_InReviewState(){
+            UserCannot_UpdateContentAndSave(_testAllRolesButAdmin, _testContentNodeEditPage, _reviewState);
+        }
+
+        void UsersCannot_UpdateContent_InModerateState(){
+            UserCannot_UpdateContentAndSave(_testAllRolesButAdmin, _testContentNodeEditPage, _moderationState);
+        }
+
+        void UsersCannot_UpdateContent_InPublishedState(){
+            UserCannot_UpdateContentAndSave(_testAllRolesButAdmin, _testContentNodeEditPage, _publishedState);         
+        }
+
+        bool ContentIsPublished(){
+            // view content in published state as anonymous user
+            return false;
+        }
+
+        void ReviewerCan_TransitionContent_FromReviewToEdit(){
+            UserCan_TransitionContentAndSave(_testReviewer, _testContentNodeViewPage, _reviewState, _editState);
+        }
+
+        void ReviewerCannot_TransitionContent_FromEditToReview(){
+            UserCannot_TransitionContentAndSave(_testReviewer, _testContentNodeViewPage, _editState, _reviewState);
+        }
+        void ReviewerCan_TransitionContent_FromReviewToModerate(){
+            UserCan_TransitionContentAndSave(_testReviewer, _testContentNodeViewPage, _reviewState, _moderationState);
+        }
+
+        void ModeratorCan_TransitionContent_FromModerateToPublished(){
+            UserCan_TransitionContentAndSave(_testModerator, _testContentNodeViewPage, _moderationState, _publishedState);
+
+            // view content in published state as anonymous user
+            DrupalLogout();
+            DrupalGet(_testContentNodeViewPage);
+            CheckIfViewPageTitleIsCorrect(_testContentNode.Title);
+        }
+
+        void PublisherCan_TransitionContent_FromPublishedToArchived(){
+            // login as publisher
+            // transition content from published into unpublished state
+            // logout
+
+            // [access denied] view content in published state as anonymous user
+            if (ContentIsPublished() == false){
+                // content is visible to anonymous user
+                // [successful]
+            }
+        }
+
+        void PublisherCan_TransitionContent_FromArchivedToPublished(){
+            // login as publisher
+            // transition content from unpublished into published state
+            // logout
+
+            // view content in published state as anonymous user
+            if (ContentIsPublished() == true){
+                // content is visible to anonymous user
+                // [successful]
+            }
+        }
+
+        void OnlyPublisherCan_UnpublishContent(){
+            // login as all-roles-but-publisher-admin
+            DrupalLogin(_testAllRolesButPublisherAdmin.Name, _testAllRolesButPublisherAdmin.Password);
+            DrupalGet(_testContentNodeEditPage);
+
+            // [access denied] unpublish content
+            // [access denied] transition content from published into unpublished state
+            // logout
+        }
+
+        void UserCan_UpdateContentAndSave(DrupalUser testUser, string nodeEditURL, string text, string workflowState){
+            AdminCan_ConfirmContent_InExpectedWorkflowState(_testContentNodeViewPage, workflowState);
+            
+            // log back in as testUser
+            DrupalLogin(testUser.Name, testUser.Password);
+            DrupalGet(nodeEditURL);
+
+            // update content and save
+            UpdateBodyField(text);
+            ScrollAndClick("edit-submit");
+
+            // confirm content is successfully updated
+            var successfulUpdateContentMessage = Driver.FindElementsByXPath($"//div[contains(@class, 'messages--status') and text()[contains(.,'has been updated.')]]");
+            Assert.AreEqual(successfulUpdateContentMessage.Count, 1);
+        }
+
+        void UserCannot_UpdateContentAndSave(DrupalUser testUser, string nodeEditURL, string workflowState){
+            AdminCan_ConfirmContent_InExpectedWorkflowState(_testContentNodeViewPage, workflowState);
+            
+            DrupalLogin(testUser.Name, testUser.Password);
+            DrupalGet(nodeEditURL);
+            Assert.AreEqual(CheckIfEditPageTitleIsCorrect(_accessDenied),true);
+        }
+
+        void UpdateBodyField(string text){
+            // Wait for the CKEditor iframe to load and switch to iframe
+            Pause(2000);
+            var editorFrame = Driver.FindElementByXPath("//div[contains(@id, 'cke_1_contents')]/iframe");
+            Driver.SwitchTo().Frame(editorFrame);
+            var editorBody = Driver.FindElementByXPath("//body");
+            editorBody.SendKeys(text);
+            Driver.SwitchTo().DefaultContent();
+        }
+
+        void UserCan_TransitionContentAndSave(DrupalUser testUser, string nodeViewURL, string currentState, string destinationState){            
+            AdminCan_ConfirmContent_InExpectedWorkflowState(nodeViewURL, currentState);
+
+            // log back in as testUser
+            DrupalLogin(testUser.Name, testUser.Password);
+
+            // set node to destination state
+            DrupalGet(nodeViewURL);
+            Select("edit-new-state",destinationState);
+            ScrollAndClick("edit-submit");
+
+            // confirm node was successfully updated
+            var successfulTransitionContentMessage = Driver.FindElementsByXPath($"//div[contains(@class, 'messages--status') and text()[contains(.,'The moderation state has been updated.')]]");
+            Assert.AreEqual(successfulTransitionContentMessage.Count, 1);
+
+            // confirm workflow state was successfully updated
+            AdminCan_ConfirmContent_InExpectedWorkflowState(nodeViewURL, destinationState);
+
+            // log back in as testUser
+            DrupalLogin(testUser.Name, testUser.Password);
+        }
+
+        void UserCannot_TransitionContentAndSave(DrupalUser testUser, string nodeViewURL, string currentState, string destinationState){
+            AdminCan_ConfirmContent_InExpectedWorkflowState(nodeViewURL, currentState);
+
+            // log back in as testUser
+            DrupalLogin(testUser.Name, testUser.Password);
+
+            // set node to destination state
+            DrupalGet(nodeViewURL);
+            var expectedWorkflowState = Driver.FindElementsByXPath($"//div[contains(@id, 'edit-current') and text()[contains(.,'{destinationState}')] and label[contains(.,'Moderation state')]]");
+            Assert.AreEqual(expectedWorkflowState.Count, 0);
+        }
+
+        void AdminCan_ConfirmContent_InExpectedWorkflowState(string nodeViewURL, string expectedState){
+            DrupalLogout();
+            DrupalLogin(_adminUser, _adminPass);
+            DrupalGet(nodeViewURL);
+            // confirm node is in expected workflow state
+            var expectedWorkflowState = Driver.FindElementsByXPath($"//div[contains(@id, 'edit-current') and text()[contains(.,'{expectedState}')] and label[contains(.,'Moderation state')]]");
+            Assert.AreEqual(expectedWorkflowState.Count, 1);
+            DrupalLogout();
+        }
+    }
+}

--- a/tests/selenium/BoveyTest/EditorialWorkflow.cs
+++ b/tests/selenium/BoveyTest/EditorialWorkflow.cs
@@ -345,10 +345,17 @@ namespace BoveyTest
             // log back in as testUser
             DrupalLogin(testUser.Name, testUser.Password);
 
-            // set node to destination state
-            DrupalGet(nodeViewURL);
-            var expectedWorkflowState = Driver.FindElementsByXPath($"//div[contains(@id, 'edit-current') and text()[contains(.,'{destinationState}')] and label[contains(.,'Moderation state')]]");
-            Assert.AreEqual(expectedWorkflowState.Count, 0);
+            if(currentState == _publishedState){
+                // attempt to set node to destination state using controls on edit URL
+                DrupalGet(nodeViewURL + "/edit");
+                var expectedWorkflowState = Driver.FindElementsByXPath($"//select[contains(@id, 'edit-moderation-state-0-state') and option[text()[contains(.,'{destinationState}')]]]");
+                Assert.AreEqual(expectedWorkflowState.Count, 0);
+            }else{
+                // attempt to set node to destination state using controls on view URL
+                DrupalGet(nodeViewURL);
+                var expectedWorkflowState = Driver.FindElementsByXPath($"//select[contains(@id, 'edit-new-state') and option[text()[contains(.,'{destinationState}')]]]");
+                Assert.AreEqual(expectedWorkflowState.Count, 0);
+            }
         }
 
         void AdminCan_ConfirmContent_InExpectedWorkflowState(string nodeViewURL, string expectedState){

--- a/tests/selenium/BoveyTest/EditorialWorkflow.cs
+++ b/tests/selenium/BoveyTest/EditorialWorkflow.cs
@@ -106,6 +106,11 @@ namespace BoveyTest
             ContentFlows_FromDraftToPublished("page");
         }
 
+        [TestMethod]
+        public void ArticleFlows_FromDraftToPublished(){
+            ContentFlows_FromDraftToPublished("article");
+        }
+
         public void ContentFlows_FromDraftToPublished(string contentType)
         {
             // ----- DRAFT PHASE ----
@@ -138,6 +143,7 @@ namespace BoveyTest
 
             // [WARNING] Users with (author OR editor) AND (reviewer, moderator, or publisher) roles can update content in review state
             // UsersCannot_UpdateContent_InModerateState();
+
             ModeratorCan_ViewContent_InModerateState();
             ModeratorCan_TransitionContent_FromModerateToPublished();
 
@@ -145,11 +151,13 @@ namespace BoveyTest
             // [WARNING] Users with (author OR editor) AND (reviewer, moderator, or publisher) roles can update content in review state
             // UsersCannot_UpdateContent_InPublishedState();
 
-
-// [WARNING] Publisher cannot unpublish at the moment - no access to button
-
-            // OnlyPublisherCan_UnpublishContent();
+            // [WARNING] Publisher cannot unpublish at the moment - no access to button
+            // OnlyPublisherCan_TransitionContent_FromPublishedToArchived();
+            
+            // [WARNING] Publisher cannot transition content at the moment - no access to button
             // PublisherCan_TransitionContent_FromPublishedToArchived();
+
+            // [WARNING] Publisher cannot transition content at the moment - no access to button
             // PublisherCan_TransitionContent_FromArchivedToPublished();
 
         }
@@ -157,6 +165,89 @@ namespace BoveyTest
         void AuthorCan_CreateDraft(string contentType) {
             UserCan_CreateContent(contentType, _testAuthor, _draftState, true);
         }
+
+        void AuthorCan_UpdateContent_InDraftState(){
+            var editText = "[Success] AuthorCan_UpdateContent_InDraftState";
+            UserCan_UpdateContentAndSave(_testAuthor, _testContentNodeEditPage, editText, _draftState);
+        }
+
+        void AuthorCan_UpdateContent_InEditState(){
+            var editText = "[Success] AuthorCan_UpdateContent_InEditState";
+            UserCan_UpdateContentAndSave(_testAuthor, _testContentNodeEditPage, editText, _editState);
+        }
+
+        void AuthorCan_TransitionContent_FromDraftToEdit(){
+            UserCan_TransitionContentAndSave(_testAuthor, _testContentNodeViewPage, _draftState, _editState);
+        }
+
+        void AuthorCan_TransitionContent_FromEditToDraft(){
+            UserCan_TransitionContentAndSave(_testAuthor, _testContentNodeViewPage, _editState, _draftState);
+        }
+
+        void EditorCan_UpdateContent_InEditState(){
+            var editText = "[Success] EditorCan_UpdateContent_InEditState";
+            UserCan_UpdateContentAndSave(_testEditor, _testContentNodeEditPage, editText, _editState);
+        }
+        
+        void EditorCan_TransitionContent_FromEditToDraft(){
+            UserCan_TransitionContentAndSave(_testEditor, _testContentNodeViewPage, _editState, _draftState);
+        }
+
+        void EditorCan_TransitionContent_FromEditToReview(){
+            UserCan_TransitionContentAndSave(_testEditor, _testContentNodeViewPage, _editState, _reviewState);
+        }
+
+        void ReviewerCan_ViewContent_InReviewState(){
+            UserCan_ViewContent(_testReviewer, _testContentNodeViewPage, _reviewState);
+        }
+
+        void ReviewerCan_TransitionContent_FromReviewToEdit(){
+            UserCan_TransitionContentAndSave(_testReviewer, _testContentNodeViewPage, _reviewState, _editState);
+        }
+
+        void ReviewerCannot_TransitionContent_FromEditToReview(){
+            UserCannot_TransitionContentAndSave(_testReviewer, _testContentNodeViewPage, _editState, _reviewState);
+        }
+        void ReviewerCan_TransitionContent_FromReviewToModerate(){
+            UserCan_TransitionContentAndSave(_testReviewer, _testContentNodeViewPage, _reviewState, _moderationState);
+        }
+
+        void ModeratorCan_ViewContent_InModerateState(){
+            UserCan_ViewContent(_testModerator, _testContentNodeViewPage, _moderationState);
+        }
+        
+        void ModeratorCan_TransitionContent_FromModerateToPublished(){
+            UserCan_TransitionContentAndSave(_testModerator, _testContentNodeViewPage, _moderationState, _publishedState);
+            AnonymousUserCan_ViewContent();
+        }
+
+        void PublisherCan_TransitionContent_FromPublishedToArchived(){
+            UserCan_TransitionContentAndSave(_testPublisher, _testContentNodeViewPage, _publishedState, _archivedState);
+            AnonymousUserCannot_ViewContent();
+        }
+
+        void PublisherCan_TransitionContent_FromArchivedToPublished(){
+            UserCan_TransitionContentAndSave(_testPublisher, _testContentNodeViewPage, _archivedState, _publishedState);
+            AnonymousUserCan_ViewContent();
+        }
+
+        void OnlyPublisherCan_TransitionContent_FromPublishedToArchived(){
+            UserCannot_TransitionContentAndSave(_testAllRolesButPublisherAdmin,_testContentNodeViewPage, _publishedState, _archivedState);
+            AnonymousUserCan_ViewContent();
+        }
+
+        void UsersCannot_UpdateContent_InReviewState(){
+            UserCannot_UpdateContentAndSave(_testAllRolesButAdmin, _testContentNodeEditPage, _reviewState);
+        }
+
+        void UsersCannot_UpdateContent_InModerateState(){
+            UserCannot_UpdateContentAndSave(_testAllRolesButAdmin, _testContentNodeEditPage, _moderationState);
+        }
+
+        void UsersCannot_UpdateContent_InPublishedState(){
+            UserCannot_UpdateContentAndSave(_testAllRolesButAdmin, _testContentNodeEditPage, _publishedState);         
+        }
+
         void UserCan_CreateContent(string contentType, DrupalUser userToCheck, string workflowState, bool needToLogin = false) {
             _testContentNode.Title = "Selenium Test Content for " + contentType;
             string editText = "[Success] UserCan_CreateContent.";
@@ -193,121 +284,11 @@ namespace BoveyTest
             _testContentNodeViewPage = "/node/" + _testContentNode.NodeID;
         }
 
-        void AuthorCan_UpdateContent_InDraftState(){
-            var editText = "[Success] AuthorCan_UpdateContent_InDraftState";
-            UserCan_UpdateContentAndSave(_testAuthor, _testContentNodeEditPage, editText, _draftState);
-        }
-
-        void AuthorCan_UpdateContent_InEditState(){
-            var editText = "[Success] AuthorCan_UpdateContent_InEditState";
-            UserCan_UpdateContentAndSave(_testAuthor, _testContentNodeEditPage, editText, _editState);
-        }
-
-        void EditorCan_UpdateContent_InEditState(){
-            var editText = "[Success] EditorCan_UpdateContent_InEditState";
-            UserCan_UpdateContentAndSave(_testEditor, _testContentNodeEditPage, editText, _editState);
-        }
-
-        void AuthorCan_TransitionContent_FromDraftToEdit(){
-            UserCan_TransitionContentAndSave(_testAuthor, _testContentNodeViewPage, _draftState, _editState);
-        }
-
-        void AuthorCan_TransitionContent_FromEditToDraft(){
-            UserCan_TransitionContentAndSave(_testAuthor, _testContentNodeViewPage, _editState, _draftState);
-        }
-
-        void EditorCan_TransitionContent_FromEditToDraft(){
-            UserCan_TransitionContentAndSave(_testEditor, _testContentNodeViewPage, _editState, _draftState);
-        }
-
-        void EditorCan_TransitionContent_FromEditToReview(){
-            UserCan_TransitionContentAndSave(_testEditor, _testContentNodeViewPage, _editState, _reviewState);
-        }
-
-        void ReviewerCan_ViewContent_InReviewState(){
-            UserCan_ViewContent(_testReviewer, _testContentNodeViewPage, _reviewState);
-        }
-
-        void ModeratorCan_ViewContent_InModerateState(){
-            UserCan_ViewContent(_testModerator, _testContentNodeViewPage, _moderationState);
-        }
-
         void UserCan_ViewContent(DrupalUser testUser, string nodeURL, string expectedWorkflowState){
             AdminCan_ConfirmContent_InExpectedWorkflowState(nodeURL, expectedWorkflowState);
             DrupalLogin(testUser.Name, testUser.Password);
             DrupalGet(nodeURL);
             Assert.AreEqual(CheckIfViewPageTitleIsCorrect(_testContentNode.Title),true);
-        }
-        
-        void UsersCannot_UpdateContent_InReviewState(){
-            UserCannot_UpdateContentAndSave(_testAllRolesButAdmin, _testContentNodeEditPage, _reviewState);
-        }
-
-        void UsersCannot_UpdateContent_InModerateState(){
-            UserCannot_UpdateContentAndSave(_testAllRolesButAdmin, _testContentNodeEditPage, _moderationState);
-        }
-
-        void UsersCannot_UpdateContent_InPublishedState(){
-            UserCannot_UpdateContentAndSave(_testAllRolesButAdmin, _testContentNodeEditPage, _publishedState);         
-        }
-
-        bool ContentIsPublished(){
-            // view content in published state as anonymous user
-            return false;
-        }
-
-        void ReviewerCan_TransitionContent_FromReviewToEdit(){
-            UserCan_TransitionContentAndSave(_testReviewer, _testContentNodeViewPage, _reviewState, _editState);
-        }
-
-        void ReviewerCannot_TransitionContent_FromEditToReview(){
-            UserCannot_TransitionContentAndSave(_testReviewer, _testContentNodeViewPage, _editState, _reviewState);
-        }
-        void ReviewerCan_TransitionContent_FromReviewToModerate(){
-            UserCan_TransitionContentAndSave(_testReviewer, _testContentNodeViewPage, _reviewState, _moderationState);
-        }
-
-        void ModeratorCan_TransitionContent_FromModerateToPublished(){
-            UserCan_TransitionContentAndSave(_testModerator, _testContentNodeViewPage, _moderationState, _publishedState);
-
-            // view content in published state as anonymous user
-            DrupalLogout();
-            DrupalGet(_testContentNodeViewPage);
-            CheckIfViewPageTitleIsCorrect(_testContentNode.Title);
-        }
-
-        void PublisherCan_TransitionContent_FromPublishedToArchived(){
-            // login as publisher
-            // transition content from published into unpublished state
-            // logout
-
-            // [access denied] view content in published state as anonymous user
-            if (ContentIsPublished() == false){
-                // content is visible to anonymous user
-                // [successful]
-            }
-        }
-
-        void PublisherCan_TransitionContent_FromArchivedToPublished(){
-            // login as publisher
-            // transition content from unpublished into published state
-            // logout
-
-            // view content in published state as anonymous user
-            if (ContentIsPublished() == true){
-                // content is visible to anonymous user
-                // [successful]
-            }
-        }
-
-        void OnlyPublisherCan_UnpublishContent(){
-            // login as all-roles-but-publisher-admin
-            DrupalLogin(_testAllRolesButPublisherAdmin.Name, _testAllRolesButPublisherAdmin.Password);
-            DrupalGet(_testContentNodeEditPage);
-
-            // [access denied] unpublish content
-            // [access denied] transition content from published into unpublished state
-            // logout
         }
 
         void UserCan_UpdateContentAndSave(DrupalUser testUser, string nodeEditURL, string text, string workflowState){
@@ -332,16 +313,6 @@ namespace BoveyTest
             DrupalLogin(testUser.Name, testUser.Password);
             DrupalGet(nodeEditURL);
             Assert.AreEqual(CheckIfEditPageTitleIsCorrect(_accessDenied),true);
-        }
-
-        void UpdateBodyField(string text){
-            // Wait for the CKEditor iframe to load and switch to iframe
-            Pause(2000);
-            var editorFrame = Driver.FindElementByXPath("//div[contains(@id, 'cke_1_contents')]/iframe");
-            Driver.SwitchTo().Frame(editorFrame);
-            var editorBody = Driver.FindElementByXPath("//body");
-            editorBody.SendKeys(text);
-            Driver.SwitchTo().DefaultContent();
         }
 
         void UserCan_TransitionContentAndSave(DrupalUser testUser, string nodeViewURL, string currentState, string destinationState){            
@@ -381,11 +352,35 @@ namespace BoveyTest
         void AdminCan_ConfirmContent_InExpectedWorkflowState(string nodeViewURL, string expectedState){
             DrupalLogout();
             DrupalLogin(_adminUser, _adminPass);
-            DrupalGet(nodeViewURL);
+            
             // confirm node is in expected workflow state
-            var expectedWorkflowState = Driver.FindElementsByXPath($"//div[contains(@id, 'edit-current') and text()[contains(.,'{expectedState}')] and label[contains(.,'Moderation state')]]");
+            DrupalGet(nodeViewURL + "/edit");
+            var expectedWorkflowState = Driver.FindElementsByXPath($"//div[contains(@id, 'edit-moderation-state-0-current') and text()[contains(.,'{expectedState}')]]");
             Assert.AreEqual(expectedWorkflowState.Count, 1);
+
             DrupalLogout();
+        }
+
+        void AnonymousUserCan_ViewContent(){
+            DrupalLogout();
+            DrupalGet(_testContentNodeViewPage);
+            CheckIfViewPageTitleIsCorrect(_testContentNode.Title);
+        }
+
+        void AnonymousUserCannot_ViewContent(){
+            DrupalLogout();
+            DrupalGet(_testContentNodeViewPage);
+            CheckIfViewPageTitleIsCorrect(_accessDenied);
+        }
+
+        void UpdateBodyField(string text){
+            // Wait for the CKEditor iframe to load and switch to iframe
+            Pause(2000);
+            var editorFrame = Driver.FindElementByXPath("//div[contains(@id, 'cke_1_contents')]/iframe");
+            Driver.SwitchTo().Frame(editorFrame);
+            var editorBody = Driver.FindElementByXPath("//body");
+            editorBody.SendKeys(text);
+            Driver.SwitchTo().DefaultContent();
         }
     }
 }

--- a/tests/selenium/BoveyTest/EditorialWorkflow.cs
+++ b/tests/selenium/BoveyTest/EditorialWorkflow.cs
@@ -151,14 +151,9 @@ namespace BoveyTest
             // [WARNING] Users with (author OR editor) AND (reviewer, moderator, or publisher) roles can update content in review state
             // UsersCannot_UpdateContent_InPublishedState();
 
-            // [WARNING] Publisher cannot unpublish at the moment - no access to button
-            // OnlyPublisherCan_TransitionContent_FromPublishedToArchived();
-            
-            // [WARNING] Publisher cannot transition content at the moment - no access to button
-            // PublisherCan_TransitionContent_FromPublishedToArchived();
-
-            // [WARNING] Publisher cannot transition content at the moment - no access to button
-            // PublisherCan_TransitionContent_FromArchivedToPublished();
+            OnlyPublisherCan_TransitionContent_FromPublishedToArchived();
+            PublisherCan_TransitionContent_FromPublishedToArchived();
+            PublisherCan_TransitionContent_FromArchivedToPublished();
 
         }
 

--- a/tests/selenium/BoveyTest/FrontEndCI.cs
+++ b/tests/selenium/BoveyTest/FrontEndCI.cs
@@ -78,7 +78,7 @@ namespace BoveyTest
 
             // Confirm that build hook is visible for permitted roles
             DrupalGet("admin/build_hooks/deployments/" + _frontEndEnv);
-            Assert.AreEqual(CheckIfPageTitleIsCorrect(_frontEndEnvTitle),true);
+            Assert.AreEqual(CheckIfEditPageTitleIsCorrect(_frontEndEnvTitle),true);
             
             // Update user to have all roles except permitted roles
             DrupalLogout();
@@ -90,7 +90,7 @@ namespace BoveyTest
 
             // Confirm that build hook is not visible for permitted roles
             DrupalGet("admin/build_hooks/deployments/" + _frontEndEnv);
-            Assert.AreEqual(CheckIfPageTitleIsCorrect("Access denied"),true);
+            Assert.AreEqual(CheckIfEditPageTitleIsCorrect("Access denied"),true);
 
             // Clean up
             DrupalLogout();


### PR DESCRIPTION
# Summary of Changes
- Updates build hook tests to use an updated DrupalTest method (name changed)
- Add editorial workflow tests for basic page and article, confirming that a draft can be created and go through the entire workflow
   - Draft to Edit
      - AuthorCan_CreateDraft(contentType);
      - AuthorCan_UpdateContent_InDraftState();
      - AuthorCan_TransitionContent_FromDraftToEdit();
      - AuthorCan_UpdateContent_InEditState();
      - AuthorCan_TransitionContent_FromEditToDraft();
      - AuthorCan_TransitionContent_FromDraftToEdit();
   - Edit to Review (including Author being able to withdraw content from Edit)
      - EditorCan_UpdateContent_InEditState();            
      - EditorCan_TransitionContent_FromEditToDraft();
      - AuthorCan_TransitionContent_FromDraftToEdit();
      - EditorCan_TransitionContent_FromEditToReview();
   - Review to Moderate (including Reviewer sending it back for more edits)
      - ReviewerCan_ViewContent_InReviewState();
      - ReviewerCan_TransitionContent_FromReviewToEdit();
      - ReviewerCannot_TransitionContent_FromEditToReview();
      - EditorCan_TransitionContent_FromEditToReview();
      - ReviewerCan_TransitionContent_FromReviewToModerate();
   - Moderate to Published
      - ModeratorCan_ViewContent_InModerateState();
      - ModeratorCan_TransitionContent_FromModerateToPublished();
   - Published to Archive and back again
      - OnlyPublisherCan_TransitionContent_FromPublishedToArchived();
      - PublisherCan_TransitionContent_FromPublishedToArchived();
      - PublisherCan_TransitionContent_FromArchivedToPublished();

# Caveat
- Currently, users with (author OR editor) AND (reviewer, moderator, or publisher) roles can update content in review state; Tests that check this behaviour have been commented out until we can confirm whether or not this feature can be added to the Content Hub.

## Pull Request Checklist

### Is Content created by the story?
- [x] No
- [ ] If yes, the content is:
   - [ ] Accessible
   - [ ] Mobile-friendly
   - [ ] Version-controlled
   - [ ] Governed by appropriate roles and permissions
   - [ ] Organized by taxonomy

### Are there User-facing changes in the Drupal UI?
- [x] No
- [ ] If yes, then:
   - [ ] User documentation is updated
   - [ ] User training is updated

### Are there Upstream Code changes?
- [ ] No
- [x] If yes, then:
   - [x] Code is complete and commented.
   - [x] Code is secure to the best of our knowledge and does not contain anything that cannot be on a public repo (e.g. passwords)
   - Is a test necessary?
      - [ ] No
      - [x] If yes, then:
         - [x] Add a test if existing tests do not effectively test the code change
         - [ ] Test passes
   - [x] Pull request (PR) is mergeable with *develop* branch
   - [x] PR has a meaningful title
   - [x] PR has a summary of changes
   - [ ] PR is peer reviewed and meets team standards.
   - [ ] PR builds without error